### PR TITLE
Bundle install

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -169,7 +169,7 @@ GEM
     minitest (5.10.3)
     multipart-post (2.0.0)
     net-dns (0.8.0)
-    nokogiri (~> 1.8.1)
+    nokogiri (1.8.1)
       mini_portile2 (~> 2.3.0)
     octokit (4.8.0)
       sawyer (~> 0.8.0, >= 0.5.3)


### PR DESCRIPTION
As a result of adding the instructed `~>` character sequence prefix to
`nokogiri` version 1.8.1 … The following message appears in the local Terminal window … “Your lockfile is unreadable. Run `rm Gemfile.lock` and then `bundle install` to generate a new lockfile.” Done.